### PR TITLE
Stubbed nil values for the describe instance calls.

### DIFF
--- a/spec/ec2_stub_spec.rb
+++ b/spec/ec2_stub_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Aws::EC2 do
     before do
       client.stub_responses(
         :describe_instances, {
+          :next_token => nil,
           :reservations => [{:instances=>[{:instance_id => "i-1", :state => {:name => "running"}, :tags =>[{:key => "Name", :value => "example-1" }]}]}]
         }
       )

--- a/spec/instance_manager_spec.rb
+++ b/spec/instance_manager_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe InstanceManager do
     before do
       ec2_client.stub_responses(
         :describe_instances,
-        { :reservations => [{ :instances => [
+        {
+          :next_token => nil,
+          :reservations => [{ :instances => [
           {
             :instance_id => "i-1",
             :state => {:name => "running" },


### PR DESCRIPTION
The default stub returns non-empty strings for all possible string values. This causes the next token that trigger paging to appear like there is a next response. These changes allow the tests to pass.

I updated your stubs to use `nil` next tokens to avoid this issue. Please feel free to open this as an issue against aws/aws-sdk-ruby as this is a poor default experience.
